### PR TITLE
Add ticket status color for "Client-Replied"

### DIFF
--- a/tickets.php
+++ b/tickets.php
@@ -314,6 +314,8 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                         $ticket_status_color = "success";
                     } elseif ($ticket_status == "Closed") {
                         $ticket_status_color = "dark";
+                    } elseif ($ticket_status == "Client-Replied") {
+                        $ticket_status_color = "warning";
                     } else{
                         $ticket_status_color = "secondary";
                     }


### PR DESCRIPTION
This pull request adds a ticket status color for the "Client-Replied" status. The color "warning" will be used to visually distinguish tickets that have received a reply from the client.