### PR TITLE
Fix increment bug in ticket_unbilled_count

### DIFF
--- a/report_tickets_unbilled.php
+++ b/report_tickets_unbilled.php
@@ -147,7 +147,7 @@ $rows = 0;
                         $ticket_unbilled_count = intval($row['ticket_unbilled_count']);
 
                         if ($ticket_unbilled_count > 0) {
-                            $rows = $rows++;
+                            $rows = $rows + 1;
 
                             ?>
 


### PR DESCRIPTION
This pull request fixes a bug in the ticket_unbilled_count variable where the increment operation was not working correctly. The bug caused incorrect counting of unbilled tickets. The issue has been resolved by changing the increment operation from "rows = rows++" to "rows = rows + 1".